### PR TITLE
Update DockerFile to always pull latest AppImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN chmod 777 /output
 
 # To upgrade, change this link here and rebuild the image. This can probably be tweaked to always pull latest.
 # RUN wget -O /usr/share/cura/Ultimaker_Cura.AppImage https://software.ultimaker.com/cura/Ultimaker_Cura-4.6.1.AppImage
-RUN wget -O /usr/share/cura/Ultimaker_Cura.AppImage https://storage.googleapis.com/software.ultimaker.com/cura/Ultimaker_Cura-4.12.0.AppImage
+# OLD METHOD STATIC URL RUN wget -O /usr/share/cura/Ultimaker_Cura.AppImage https://storage.googleapis.com/software.ultimaker.com/cura/Ultimaker_Cura-4.12.0.AppImage
+RUN wget -O /usr/share/cura/Ultimaker_Cura.AppImage $(curl -s https://api.github.com/repos/Ultimaker/Cura/releases | grep browser_download_url | grep '.AppImage' | head -n 1 | cut -d '"' -f 4)
 RUN chmod a+x /usr/share/cura/Ultimaker_Cura.AppImage
 
 # Copy the start script.


### PR DESCRIPTION
Update the script to pull the latest release AppImage and use that instead. Let me know what you think, I tested it here and it seems to work fine, reliably is pulling down 4.13 now. 